### PR TITLE
로그인 유지 안되는 것과 특정 경우에 token 갱신 횟수가 많아지는 버그 수정

### DIFF
--- a/src/modules/auth/authThunk.ts
+++ b/src/modules/auth/authThunk.ts
@@ -9,11 +9,17 @@ import { getUserInfo } from '../../api/user';
 const JWT_EXPIRY_TIME = 3600*1000;
 const JWT_REFRESH_FREQUENCY = JWT_EXPIRY_TIME / 2;
 
+let refreshTimeOutID = -1
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const refresh = async (dispatch: any) => {
   const savedUserToken = localStorageService.getUserTokenFromLocalStorage();
   if(savedUserToken == null) {
     return;
+  }
+
+  if(refreshTimeOutID != -1) {
+    window.clearTimeout(refreshTimeOutID)
   }
 
   try {
@@ -23,7 +29,7 @@ const refresh = async (dispatch: any) => {
 
     axios.defaults.headers.common['x-access-token'] = accessToken;
 
-    setTimeout(() => {
+    refreshTimeOutID = window.setTimeout(() => {
       refresh(dispatch);
     }, JWT_REFRESH_FREQUENCY);
   } catch (e) {

--- a/src/modules/auth/authThunk.ts
+++ b/src/modules/auth/authThunk.ts
@@ -70,8 +70,7 @@ const getSavedLoginThunk = (): ThunkAction<void, RootState, null, AuthAction> =>
       return;
     }
   
-    axios.defaults.headers.common['x-access-token'] = savedUserToken.yasAccessToken;
-    
+    await refresh(dispatch);
     const userInfo = await getUserInfo();
 
     // if api call fails
@@ -80,7 +79,6 @@ const getSavedLoginThunk = (): ThunkAction<void, RootState, null, AuthAction> =>
       dispatch(logoutThunk());
     } else{
       dispatch(loginSuccess(userInfo, savedUserToken));
-      refresh(dispatch);
     }
   }
 }


### PR DESCRIPTION
closed #48

- 일정 시간 후에 다시 웹을 켜면 로그인이 풀려있는 버그 수정
- refresh 함수가 setTimeout을 통해 재귀적으로 불리고 있어서, 밖에서 refresh 함수를 여러번 부르면 함수 호출 빈도가 점점 높아지는 버그 수정.